### PR TITLE
🐛 投稿一覧の画像を固定長で表示されるように修正 #1

### DIFF
--- a/src/components/PostAbout.js
+++ b/src/components/PostAbout.js
@@ -5,21 +5,19 @@ const PostAbout = ({ props }, index) => {
   return (
     <Link to={`/post/${props.id}`}>
       <div key={"post-about-" + String(index)} className="flex mb-8 p-4 bg-indigo-50 shadow-md">
+        <span className="flex-none bg-gray-300 mr-4 my-auto h-40 w-40">
+          {props.thumbnail ? (
+            <img
+              src={props.thumbnail.url}
+              alt={`thumbnail-${props.id}`}
+              className="object-cover my-auto h-40 w-40"
+            ></img>
+          ) : (
+            <img src={noImg} alt="no-thumbnail" className="object-cover my-auto h-40 w-40"></img>
+          )}
+        </span>
         <div>
-          <span className="bg-gray-300">
-            {props.thumbnail ? (
-              <img
-                src={props.thumbnail.url}
-                alt={`thumbnail-${props.id}`}
-                className="object-cover h-40 w-40 mx-6"
-              ></img>
-            ) : (
-              <img src={noImg} alt="no-thumbnail" className="object-cover h-40 w-40 mx-6"></img>
-            )}
-          </span>
-        </div>
-        <div>
-          <h3 className="text-2xl font-medium mt-2 mb-2">{props.title}</h3>
+          <h3 className="text-2xl font-medium">{props.title}</h3>
           <div className="mb-2">
             <span className="mr-4">{props.publishedAt.slice(0, 10)}</span>
             <span>{props.category.category}</span>


### PR DESCRIPTION
フレックスが適用されていたため、画像の領域も伸縮されてしまい、画像が思ったとおりに表示できていませんでした。
画像領域を`flex-none`により、フレックスのフレックスを無効にすることで、固定長で表示されるように修正しました。
その他、マージン等の微修正が含まれています。